### PR TITLE
Publish-to-pypi workflow: hatch instead of pypi-publish

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -27,16 +27,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.8'
-        cache: "pip"
+    - name: Install Hatch
+      run: pip install hatch
 
     - name: Build package
-      run: python -m build
+      run: hatch build
 
     - name: Publish marqo-haystack
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_MARQO_HAYSTACK_TOKEN }}
+      env:
+        HATCH_INDEX_USER: __token__
+        HATCH_INDEX_AUTH: ${{ secrets.PYPI_MARQO_HAYSTACK_TOKEN }}
+      run: hatch publish -y


### PR DESCRIPTION
The original pypi-publish workflow attempted to pip install from requirements.txt, resulting in a workflow failure. 

Hatch is used instead, which doesn't result in a failure. 

However, we can only really know the success of this action when the version is bumped, and a new version appears of this package appears on PyPi.